### PR TITLE
Update license headers and files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Olivier Verville
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/D2Constants.h
+++ b/src/D2Constants.h
@@ -1,7 +1,19 @@
-#pragma once
-
-#ifndef _D2CONSTANTS_H
-#define _D2CONSTANTS_H
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -35,6 +47,11 @@
 *   this value, you only need to change your constant's value               *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2CONSTANTS_H
+#define _D2CONSTANTS_H
 
 enum D2C_UnitTypes
 {

--- a/src/D2DataTables.h
+++ b/src/D2DataTables.h
@@ -1,9 +1,19 @@
-#pragma once
-
-#ifndef _D2DATATABLES_H
-#define _D2DATATABLES_H
-
-#pragma pack(1)
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -31,6 +41,11 @@
 *   by the game, such as Monstats.txt or Charstats.txt                      *
 *                                                                           *
 *****************************************************************************/
+
+#ifndef _D2DATATABLES_H
+#define _D2DATATABLES_H
+
+#pragma pack(1)
 
 /****************************************************************************
 *                                                                           *

--- a/src/D2PacketDef.h
+++ b/src/D2PacketDef.h
@@ -1,9 +1,19 @@
-#pragma once
-
-#ifndef _D2PACKETDEF_H
-#define _D2PACKETDEF_H
-
-#pragma pack(1)
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -31,6 +41,13 @@
 *   handle communications between the server and the client                 *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PACKETDEF_H
+#define _D2PACKETDEF_H
+
+#pragma pack(1)
 
 /****************************************************************************
 *                                                                           *

--- a/src/D2Patch.h
+++ b/src/D2Patch.h
@@ -1,9 +1,19 @@
-#pragma once
-
-#ifndef _D2PATCH_H
-#define _D2PATCH_H
-
-#include "D2PatchConst.h"
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -31,6 +41,13 @@
 *   array, in order to be handled by D2Template's patcher                   *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PATCH_H
+#define _D2PATCH_H
+
+#include "D2PatchConst.h"
 
 static const DLLPatchStrc gptTemplatePatches[] =
 {

--- a/src/D2PatchConst.h
+++ b/src/D2PatchConst.h
@@ -1,7 +1,19 @@
-#pragma once
-
-#ifndef _D2PATCHCONST_H
-#define _D2PATCHCONST_H
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -29,6 +41,11 @@
 *   know what you're doing.                                                 *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PATCHCONST_H
+#define _D2PATCHCONST_H
 
 #define PATCH_JMP               0x000000E9
 #define PATCH_CALL              0x000000E8

--- a/src/D2Ptrs.h
+++ b/src/D2Ptrs.h
@@ -1,7 +1,19 @@
-#pragma once
-
-#ifndef _D2PTRS_H
-#define _D2PTRS_H
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -31,6 +43,11 @@
 *   them by address can also end up being very useful                       *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PTRS_H
+#define _D2PTRS_H
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //  These are the macros used by the template core to declare                                                                                                                                                                   ///

--- a/src/D2Structs.h
+++ b/src/D2Structs.h
@@ -1,11 +1,19 @@
-#pragma once
-
-#ifndef _D2STRUCTS_H
-#define _D2STRUCTS_H
-
-#include "D2DataTables.h"
-#include "D2PacketDef.h"
-#pragma pack(1)
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -32,6 +40,16 @@
 *   a unit entity, or a game entity                                         *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef D2TEMPLATE89_D2STRUCTS_H_
+#define D2TEMPLATE89_D2STRUCTS_H_
+
+#include "D2DataTables.h"
+#include "D2PacketDef.h"
+
+#pragma pack(1)
 
 /****************************************************************************
 *                                                                           *

--- a/src/D2Vars.h
+++ b/src/D2Vars.h
@@ -1,8 +1,19 @@
-#ifdef _D2VARS_H
-#define VAR(Type, Name)         Type Name;
-#else
-#define VAR(Type, Name)         extern Type Name;
-#endif
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -28,6 +39,12 @@
 *   within your code. These variables can be used anywhere in your code     *
 *                                                                           *
 *****************************************************************************/
+
+#ifdef _D2VARS_H
+#define VAR(Type, Name)         Type Name;
+#else
+#define VAR(Type, Name)         extern Type Name;
+#endif
 
 VAR(DWORD, SampleVariable1)
 

--- a/src/DLLmain.cpp
+++ b/src/DLLmain.cpp
@@ -1,7 +1,19 @@
-#define _D2VARS_H
-
-#include "DLLmain.h"
-#include "D2Patch.h"
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /****************************************************************************
 *                                                                           *
@@ -26,6 +38,11 @@
 *   D2Template core file, do not modify unless you know what you're doing   *
 *                                                                           *
 *****************************************************************************/
+
+#define _D2VARS_H
+
+#include "DLLmain.h"
+#include "D2Patch.h"
 
 void __fastcall D2TEMPLATE_FatalError(char* szMessage)
 {

--- a/src/DLLmain.h
+++ b/src/DLLmain.h
@@ -1,3 +1,20 @@
+/**
+ * D2Template89
+ * Copyright 2021 Mir Drualga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /****************************************************************************
 *                                                                           *
 *   DLLmain.h                                                               *


### PR DESCRIPTION
These changes add D2Template89's license header to files, and reverts the LICENSE file to the unmodified Apache 2.0 file.